### PR TITLE
ci(workflow):update-closed-issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,0 +1,23 @@
+name: Test Issue Close Trigger
+permissions:
+  contents: read
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print closed issue info
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "Issue Number: $ISSUE_NUMBER"
+          # Prevent workflow command injection from untrusted issue titles
+          TOKEN=$(uuidgen)
+          echo "::stop-commands::${TOKEN}"
+          echo "Title: $ISSUE_TITLE"
+          echo "::${TOKEN}::"
+          echo "Workflow triggered successfully when issue was closed."

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,0 +1,39 @@
+name: Set Project Closed Date
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
+  CLOSED_DATE_FIELD: "Closed Date"
+
+jobs:
+  set-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve closed date
+        id: when
+        shell: bash
+        run: |
+          ts='${{ github.event.issue.closed_at }}'
+          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
+            echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
+            exit 1
+          fi
+          d=$(date -u -d "$ts" +%F)
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+          echo "Closed date -> $d"
+
+      # Update the "Closed Date" field on that project item
+      - name: Update Closed Date field
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.ORG_PROJECT_PAT }}
+          field-name: ${{ env.CLOSED_DATE_FIELD }}
+          field-value: ${{ steps.when.outputs.date }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Resolve closed date
         id: when
         shell: bash
+        env:
+          CLOSED_AT: ${{ github.event.issue.closed_at }}
         run: |
-          ts='${{ github.event.issue.closed_at }}'
+          ts="$CLOSED_AT"
           if [ -z "$ts" ] || [ "$ts" = "null" ]; then
             echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
             exit 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two GitHub Actions that run when an issue is closed: one sets the project item’s “Closed Date”, and one verifies the trigger. Also enable weekly Dependabot updates for `github-actions`.

- **New Features**
  - `Set Project Closed Date` workflow: reads `closed_at`, formats the UTC date, and updates the “Closed Date” field via `nipe0324/update-project-v2-item-field`. Fails safely if `closed_at` is missing.
  - `Test Issue Close Trigger` workflow: prints issue number/title and disables workflow commands to prevent injection.
  - Weekly Dependabot for `github-actions`.

- **Migration**
  - Add the `ORG_PROJECT_PAT` secret with access to Projects v2 and issues.
  - Ensure the configured project exists and has a “Closed Date” field.

<sup>Written for commit 156f79b34158b1048a9bb7fdd0bfaaa7b741ac4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Dependabot configuration to enable weekly automated updates for GitHub Actions dependencies.
  * Added two workflows triggered on issue closure: one to run a test/log job and another to compute the closed date and update project metadata accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->